### PR TITLE
fix #1 with explicit link color

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -30,3 +30,7 @@ h1 {
 #navigation ul {
     float: right;
 }
+
+a {
+    color: #8f8fff;
+}


### PR DESCRIPTION
fixes #1

Explicitly set a color for links. This color increases the contrast ratio from 1.34:1 to 4.54:1.

Before:
![image](https://cloud.githubusercontent.com/assets/2237299/11009046/54a7668a-8489-11e5-99df-dd15e1f0fe9a.png)

After:
![image](https://cloud.githubusercontent.com/assets/2237299/11009053/698bb4ac-8489-11e5-8830-daefecd8884b.png)
